### PR TITLE
Add to dev-tools repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildDebArchAll()
+buildDebArchAll repos: ['release', 'devTools']


### PR DESCRIPTION
Нужно, чтобы в modbus-utils-rpc запускались питоновые проверки. Они запускаются в контейнере, перед запуском проверок ставятся build deps, а этого пакета  dev tools нет и все разваливается